### PR TITLE
fix(Gift page change): When action payload contains spacebar there is…

### DIFF
--- a/backend/src/common/services/gift.ts
+++ b/backend/src/common/services/gift.ts
@@ -62,7 +62,7 @@ export default class GiftService {
     const selectedOption = {
       text: {
         emoji: true,
-        text: `Page ${page}`,
+        text: `Page\xa0${page}`,
         type: "plain_text"
       },
       value: page.toString()
@@ -70,7 +70,7 @@ export default class GiftService {
     const options = _range(1, totalPages).map(i => ({
       text: {
         emoji: true,
-        text: `Page ${i}`,
+        text: `Page\xa0${i}`,
         type: "plain_text"
       },
       value: i.toString()


### PR DESCRIPTION
… error with hash it

From now in actions if one need to use spacebar then one nieed use \xa0